### PR TITLE
Upgrade to Spring Boot 1.5.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -14,8 +14,8 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>1.4.3.RELEASE</version>
-		<relativePath /> <!-- lookup parent from repository -->
+		<version>1.5.2.RELEASE</version>
+		<relativePath />
 	</parent>
 
 	<properties>

--- a/src/main/java/de/timeline/Event.java
+++ b/src/main/java/de/timeline/Event.java
@@ -6,7 +6,7 @@ import java.util.UUID;
 import javax.validation.constraints.Past;
 import javax.validation.constraints.Size;
 
-import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 
 import lombok.AllArgsConstructor;
 import lombok.Data;
@@ -15,8 +15,8 @@ import lombok.RequiredArgsConstructor;
 @Data
 @AllArgsConstructor
 @RequiredArgsConstructor
+@JsonIgnoreProperties(value = "eventId", allowGetters = true)
 public class Event {
-	@JsonIgnore
 	private UUID eventId;
 	@Size(min = 3, message = "You must use at least 3 characters")
 	private final String eventName;


### PR DESCRIPTION
ZonedDateTime serializes to a quite simpledouble value which seems to be, after some more investigation, really working fine, even with time zone in it.
So this one just upgrades the whole project to that latest Spring Boot version.

For the future: Please check for updates regularly using:
```
mvn versions:display-dependency-updates
```
…which shows currently:
```
[INFO] The following dependencies in Dependencies have newer versions:
[INFO]   io.rest-assured:rest-assured .......................... 3.0.1 -> 3.0.2
[INFO]   org.testng:testng ..................................... 6.9.10 -> 6.11
```
Please figure out, what Maven wants to tell us and how to handle it!